### PR TITLE
Added Regional Forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The author will make reasonable efforts to keep it up to date and fully featured
  * Daily (Two timesteps, midday and midnight UTC)
  * 3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)
 * Get hourly observations for the last 48 hours
+* Get regional forecasts summarys for the following 30 days
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The author will make reasonable efforts to keep it up to date and fully featured
  * Daily (Two timesteps, midday and midnight UTC)
  * 3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)
 * Get hourly observations for the last 48 hours
-* Get regional forecast summaries for the following 30 days
+* Get regional forecasts for the next 30 days (Grouped in four timesteps)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The author will make reasonable efforts to keep it up to date and fully featured
  * Daily (Two timesteps, midday and midnight UTC)
  * 3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)
 * Get hourly observations for the last 48 hours
-* Get regional forecast summarys for the following 30 days
+* Get regional forecast summaries for the following 30 days
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The author will make reasonable efforts to keep it up to date and fully featured
  * Daily (Two timesteps, midday and midnight UTC)
  * 3 hourly (Eight timesteps, every 3 hours starting at midnight UTC)
 * Get hourly observations for the last 48 hours
-* Get regional forecasts summarys for the following 30 days
+* Get regional forecast summarys for the following 30 days
 
 ## Installation
 

--- a/examples/hello_world/api_test.js
+++ b/examples/hello_world/api_test.js
@@ -26,3 +26,19 @@ var forecast_for_today = forecast.days[0]
 var next_forecast = forecast_for_today.timesteps[1]
 
 console.log("At " + next_forecast.date + " it will be " + next_forecast.weather.text + " with a temperature of " + next_forecast.temperature.value + "°" + next_forecast.temperature.units + " in " + obs_site.name)
+
+// We can get a general regional reports using the region id
+// Note the region id's are not the same as the site ID so lest list them
+var reg_sites = datapoint.get_regional_forecast_sites();
+for (var i = 0; i < reg_sites.length; i++) {
+    var region_ids = reg_sites[i]['@id']+' '+reg_sites[i]['@name'];
+    console.log(region_ids);
+}
+
+// We can then print out todays forecasts
+var reg_forecast = datapoint.get_regional_forecast_for_site("514");
+
+var todays_headline = reg_forecast.days[0].Paragraph;
+for (var i = 0; i < todays_headline.length; i++) {
+    console.log(todays_headline[i].title + todays_headline[i].$);
+}

--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,7 @@ module.exports = {
 
   "FCS_URL": "http://datapoint.metoffice.gov.uk/public/data/val/wxfcs/all/json/",
   "OBS_URL": "http://datapoint.metoffice.gov.uk/public/data/val/wxobs/all/json/",
+  "RFCS_URL": "http://datapoint.metoffice.gov.uk/public/data/txt/wxfcs/regionalforecast/json/",
 
   "formatParams": function( params ){
     return "?" + Object
@@ -36,6 +37,8 @@ module.exports = {
       var url = this.FCS_URL
     } else if (type == "obs") {
       var url = this.OBS_URL
+    } else if (type == "rfcs") {
+      var url = this.RFCS_URL
     } else {
       console.log("No request type set.");
       return false;

--- a/src/datapoint.js
+++ b/src/datapoint.js
@@ -38,7 +38,7 @@ module.exports = {
    * Get a list of regional forecast sites.
    * @returns {Array} - List of site objects.
    */
-  get_regional_forecast_site: function(){
+  get_regional_forecast_sites: function(){
     return site.get_sites(this.api_key, "rfcs");
   },
 

--- a/src/datapoint.js
+++ b/src/datapoint.js
@@ -39,7 +39,7 @@ module.exports = {
    * @returns {Array} - List of site objects.
    */
   get_regional_forecast_sites: function(){
-    return site.get_sites(this.api_key, "rfcs");
+    return site.get_regional_sites(this.api_key, "rfcs");
   },
 
   /**

--- a/src/datapoint.js
+++ b/src/datapoint.js
@@ -35,6 +35,14 @@ module.exports = {
   },
 
   /**
+   * Get a list of regional forecast sites.
+   * @returns {Array} - List of site objects.
+   */
+  get_regional_forecast_site: function(){
+    return site.get_sites(this.api_key, "rfcs");
+  },
+
+  /**
    * Get nearest forecast site.
    * @param {string} longitude - Logitude for location.
    * @param {string} latitude - Latitude for location.
@@ -71,6 +79,15 @@ module.exports = {
    */
   get_obs_for_site: function(site_id){
     return obs.get_obs_for_site(this.api_key, site_id);
+  },
+
+  /**
+   * Get regional forecast for site.
+   * @param {string} site_id - ID of site to get regional forecast for.
+   * @returns {Object}  - Forecast object.
+   */
+  get_regional_forecast_for_site: function(site_id){
+    return forecast.get_regional_forecast_for_site(this.api_key, site_id);
   }
 }
 

--- a/src/forecast.js
+++ b/src/forecast.js
@@ -33,13 +33,24 @@ module.exports = {
     var data = api.call_api(api_key, "rfcs", site_id);
     data = data.RegionalFcst;
     var forecast = {};
-    forecast.issued_at = data.issuedAt;
-    forecast.created_on = data.createdOn;
-    forecast.region = data.regionId;
-    forecast.days = data.FcstPeriods.Period;
-    // // //
+    forecast.issued_at   = new Date(data.issuedAt);
+    forecast.created_on  = new Date(data.createdOn);
+    forecast.region_id   = data.regionId;
+    forecast.region_name = this.parse_region_id(data.regionId);
+    forecast.days        = data.FcstPeriods.Period;
+
     return forecast;
 
+  },
+
+  "parse_region_id": function(key) {
+    // Return friendly region name
+    if (key in settings.region_ids){
+      return settings.region_ids[key];
+    } else {
+      console.log("Unknown key " + key);
+      return undefined;
+    }
   },
 
   "clean_days": function(raw_data){

--- a/src/forecast.js
+++ b/src/forecast.js
@@ -29,6 +29,19 @@ module.exports = {
 
   },
 
+  "get_regional_forecast_for_site": function(api_key, site_id){
+    var data = api.call_api(api_key, "rfcs", site_id);
+    data = data.RegionalFcst;
+    var forecast = {};
+    forecast.issued_at = data.issuedAt;
+    forecast.created_on = data.createdOn;
+    forecast.region = data.regionId;
+    forecast.days = data.FcstPeriods.Period;
+    // // //
+    return forecast;
+
+  },
+
   "clean_days": function(raw_data){
     var days = [];
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -61,6 +61,27 @@ module.exports = {
     "28":"Thunder shower (night)",
     "29":"Thunder shower (day)",
     "30":"Thunder"
+  },
+
+  "region_ids": {
+    "os": "Orkney & Shetland",
+    "he": "Highland & Eilean Siar",
+    "gr": "Grampian",
+    "ta": "Tayside",
+    "st": "Strathclyde",
+    "dg": "Dumfries, Galloway, Lothian",
+    "ni": "Northern Ireland",
+    "yh": "Yorkshire & the Humber",
+    "ne": "Northeast England",
+    "em": "East Midlands",
+    "ee": "East of England",
+    "se": "London & Southeast England",
+    "nw": "Northwest England",
+    "wm": "West Midlands",
+    "sw": "Southwest England",
+    "wl": "Wales",
+    "uk": "UK"
   }
+
 
 };

--- a/src/site.js
+++ b/src/site.js
@@ -1,10 +1,26 @@
 var api = require("./api");
+var settings = require("./settings");
 
 module.exports = {
 
     "get_sites": function(api_key, type){
-      sites = api.call_api(api_key, type, "sitelist/")
+      sites = api.call_api(api_key, type, "sitelist/");
       return sites.Locations.Location;
+    },
+
+    "get_regional_sites": function(api_key, type){
+      sites = api.call_api(api_key, type, "sitelist/");
+      sites = sites.Locations.Location
+
+      // Return readable site names
+      for (var i = 0; i < sites.length; i++) {
+        var site_id = sites[i]['@name'];
+        if (site_id in settings.region_ids){
+          sites[i]['@name'] = settings.region_ids[site_id];
+        }
+      }
+
+      return sites;
     },
 
     "distance_between_coords": function(lon1, lat1, lon2, lat2){


### PR DESCRIPTION
I thought it would be useful to include the regional forecast data so I've updated **api.js** to include the regional URL and created a couple of functions to return regional sites and forecasts.
Example **api_test.js** and **README** also updated.
### Amendments:

- **api.js**
  - Added regional forecast URL:`"RFCS_URL"`
  - Updated if case in `formatParams()`
- **settings.js**
  - Added region id and friendly names
- **site.js**
  - Created `get_regional_sites()` function to return friendly region names
- **forecast.js**
  - Created `get_regional_forecast_for_site()`
  - Created `parse_region_id()` to include region name as part of `get_regional_forecast_for_site()` output
- **datapoint.js**
  - Added `get_regional_forecast_sites()`
  - Added `get_regional_forecast_for_site()`